### PR TITLE
[ FIX ] - Alterei a importação do repository do explorer na entidade do typeORM.

### DIFF
--- a/src/modules/coin/typeorm/repositories/ExplorerRepository.ts
+++ b/src/modules/coin/typeorm/repositories/ExplorerRepository.ts
@@ -1,5 +1,6 @@
-import { ICreateExplorerDTO } from "@modules/cryptocurrencies/dtos/ICreateExplorerDTO";
-import { IExplorerRepository } from "@modules/cryptocurrencies/repositories/IExplorerRepository";
+
+import { ICreateExplorerDTO } from "@modules/coin/dtos/ICreateExplorerDTO";
+import { IExplorerRepository } from "@modules/coin/repositories/IExplorerRepository";
 import { getRepository, Repository } from "typeorm";
 import { Explorer } from "../entities/Explorer";
 


### PR DESCRIPTION
As seguintes intefaces : ICreateExplorerDTO e IExplorerRepository estavam sendo importadas dentro do módulo do cryptocurrencies que já não existe mais.